### PR TITLE
Nora

### DIFF
--- a/delicatessen/delicatessen_version.py
+++ b/delicatessen/delicatessen_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev49+g22f2a73.d20200910"
+__version__ = "0.1.dev57+g9df5ac9"

--- a/delicatessen/tools/delilatte.py
+++ b/delicatessen/tools/delilatte.py
@@ -410,9 +410,9 @@ class DeliLATTE(BaseTool):
             y="y",
             source=self.source,
             line_color=None,
-            color="orange",
-            alpha=0.9,
-        )
+            color="darkorange",
+            alpha=0.8,
+            size =3)
 
         self.plot.circle(
             x="x_binned",
@@ -421,7 +421,7 @@ class DeliLATTE(BaseTool):
             line_color=None,
             color="black",
             alpha=0.5,
-        )
+            size =3)
 
         # axis labels
         self.plot.xaxis.axis_label = "Time (BJD - 2457000)"
@@ -445,7 +445,8 @@ class DeliLATTE(BaseTool):
             source=self.source_bkg,
             line_color=None,
             color="blue",
-            alpha=0.5,)
+            alpha=0.5,
+            size =3)
 
         self.plot_bkg.xaxis.axis_label = "Time (BJD - 2457000)"
         self.plot_bkg.yaxis.axis_label = "Background Flux"
@@ -479,7 +480,8 @@ class DeliLATTE(BaseTool):
             source=self.source_xcen1,
             line_color=None,
             color="red",
-            alpha=0.3,)
+            alpha=0.4,
+            size = 2)
 
         self.plot_xcen.circle(
             x="x_xcen2",
@@ -487,7 +489,8 @@ class DeliLATTE(BaseTool):
             source=self.source_xcen2,
             line_color=None,
             color="black",
-            alpha=0.3,)
+            alpha=0.3,
+            size =2)
 
         self.plot_ycen.circle(
             x="x_ycen1",
@@ -495,7 +498,8 @@ class DeliLATTE(BaseTool):
             source=self.source_ycen1,
             line_color=None,
             color="red",
-            alpha=0.3,)
+            alpha=0.4,
+            size =2)
 
         self.plot_ycen.circle(
             x="x_ycen2",
@@ -503,7 +507,8 @@ class DeliLATTE(BaseTool):
             source=self.source_ycen2,
             line_color=None,
             color="black",
-            alpha=0.3,)
+            alpha=0.3,
+            size =2)
 
 
         #self.plot_xcen.xaxis.axis_label = "Time (BJD - 2457000)"

--- a/delicatessen/tools/delilatte.py
+++ b/delicatessen/tools/delilatte.py
@@ -402,7 +402,7 @@ class DeliLATTE(BaseTool):
         )
 
         self.plot = figure(
-            plot_height=320, plot_width=500, title="", sizing_mode="scale_both"
+            plot_height=300, plot_width=1200, title="", sizing_mode="scale_both"
         )
 
         self.plot.circle(
@@ -436,7 +436,7 @@ class DeliLATTE(BaseTool):
 
         # add an extra figure to plot an additional parameter - such as the background or the centroid shifts. 
         self.plot_bkg = figure(
-            plot_height=300, plot_width=500, title="", sizing_mode="scale_both", x_range=self.plot.x_range
+            plot_height=400, plot_width=1200, title="", sizing_mode="scale_both", x_range=self.plot.x_range
         )
 
         self.plot_bkg.circle(
@@ -468,10 +468,10 @@ class DeliLATTE(BaseTool):
             data=dict(x_ycen2=[], y_ycen2=[]))
 
         self.plot_xcen = figure(
-            plot_height=200, plot_width=600, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
+            plot_height=200, plot_width=1200, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
         
         self.plot_ycen = figure(
-            plot_height=200, plot_width=600, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
+            plot_height=200, plot_width=1200, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
 
 
         self.plot_xcen.circle(
@@ -528,7 +528,7 @@ class DeliLATTE(BaseTool):
 
         # add an extra figure to plot an additional parameter - such as the background or the centroid shifts. 
         self.plot_periodgrm = figure(
-            plot_height=300, plot_width=500, title="", sizing_mode="scale_both", x_axis_type="log", y_axis_type="log")
+            plot_height=400, plot_width=1200, title="", sizing_mode="scale_both", x_axis_type="log", y_axis_type="log")
 
         self.plot_periodgrm.line(
             x="x_periodgrm",
@@ -677,5 +677,5 @@ class DeliLATTE(BaseTool):
         tabs = Tabs(tabs=panels, css_classes=["tabs"])
 
 
-        return row(self.plot, tabs)
+        return column(self.plot, tabs)
 

--- a/delicatessen/tools/delilatte.py
+++ b/delicatessen/tools/delilatte.py
@@ -467,10 +467,10 @@ class DeliLATTE(BaseTool):
             data=dict(x_ycen2=[], y_ycen2=[]))
 
         self.plot_xcen = figure(
-            plot_height=200, plot_width=550, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
+            plot_height=200, plot_width=600, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
         
         self.plot_ycen = figure(
-            plot_height=200, plot_width=550, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
+            plot_height=200, plot_width=600, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
 
 
         self.plot_xcen.circle(

--- a/delicatessen/tools/delilatte.py
+++ b/delicatessen/tools/delilatte.py
@@ -3,18 +3,19 @@ from .base import BaseTool
 
 # Third-party
 import numpy as np
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnDataSource, Panel, Tabs
 from bokeh.plotting import figure
 
 import sys
 import json
 import requests
+import lightkurve as lk
 from urllib.parse import quote as urlencode
 from tess_stars2px import tess_stars2px_function_entry
 
 import http.client as httplib
 import astropy.io.fits as pf
-
+from bokeh.layouts import column, row, Spacer
 # --- functions needed to download the TESS data
 
 
@@ -392,7 +393,6 @@ def download_data(tic, binfac=5, test="no"):
 
 # - - - - - - - - - - - - - - - - - - - - - - - - -
 
-
 class DeliLATTE(BaseTool):
     def __init__(self, parent):
         self.parent = parent
@@ -402,7 +402,7 @@ class DeliLATTE(BaseTool):
         )
 
         self.plot = figure(
-            plot_height=300, plot_width=700, title="", sizing_mode="scale_both"
+            plot_height=320, plot_width=500, title="", sizing_mode="scale_both"
         )
 
         self.plot.circle(
@@ -423,17 +423,132 @@ class DeliLATTE(BaseTool):
             alpha=0.5,
         )
 
-        # add an extra figure...?
-        self.plot_extra = figure(
-            plot_height=300, plot_width=700, title="", sizing_mode="scale_both"
-        )
-
         # axis labels
         self.plot.xaxis.axis_label = "Time (BJD - 2457000)"
         self.plot.yaxis.axis_label = "Normalised Flux"
 
+
+        # - - - Backgrounds - - - -
+        # - - - - - - - - - - - - -
+
+        self.source_bkg = ColumnDataSource(
+            data=dict(x_bkg=[], y_bkg=[]))
+
+        # add an extra figure to plot an additional parameter - such as the background or the centroid shifts. 
+        self.plot_bkg = figure(
+            plot_height=300, plot_width=500, title="", sizing_mode="scale_both", x_range=self.plot.x_range
+        )
+
+        self.plot_bkg.circle(
+            x="x_bkg",
+            y="y_bkg",
+            source=self.source_bkg,
+            line_color=None,
+            color="blue",
+            alpha=0.5,)
+
+        self.plot_bkg.xaxis.axis_label = "Time (BJD - 2457000)"
+        self.plot_bkg.yaxis.axis_label = "Background Flux"
+
+
+        # - - - Centroic Plot - - - 
+        # - - - - - - - - - - - - - 
+
+        self.source_xcen1 = ColumnDataSource(
+            data=dict(x_xcen1=[], y_xcen1=[]))
+
+        self.source_xcen2 = ColumnDataSource(
+            data=dict(x_xcen2=[], y_xcen2=[]))
+
+        self.source_ycen1 = ColumnDataSource(
+            data=dict(x_ycen1=[], y_ycen1=[]))
+
+        self.source_ycen2 = ColumnDataSource(
+            data=dict(x_ycen2=[], y_ycen2=[]))
+
+        self.plot_xcen = figure(
+            plot_height=200, plot_width=550, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
+        
+        self.plot_ycen = figure(
+            plot_height=200, plot_width=550, title="", sizing_mode="scale_both", x_range=self.plot.x_range)
+
+
+        self.plot_xcen.circle(
+            x="x_xcen1",
+            y="y_xcen1",
+            source=self.source_xcen1,
+            line_color=None,
+            color="red",
+            alpha=0.3,)
+
+        self.plot_xcen.circle(
+            x="x_xcen2",
+            y="y_xcen2",
+            source=self.source_xcen2,
+            line_color=None,
+            color="black",
+            alpha=0.3,)
+
+        self.plot_ycen.circle(
+            x="x_ycen1",
+            y="y_ycen1",
+            source=self.source_ycen1,
+            line_color=None,
+            color="red",
+            alpha=0.3,)
+
+        self.plot_ycen.circle(
+            x="x_ycen2",
+            y="y_ycen2",
+            source=self.source_ycen2,
+            line_color=None,
+            color="black",
+            alpha=0.3,)
+
+
+        #self.plot_xcen.xaxis.axis_label = "Time (BJD - 2457000)"
+        self.plot_xcen.yaxis.axis_label = "x-centroid"
+        self.plot_ycen.xaxis.axis_label = "Time (BJD - 2457000)"
+        self.plot_ycen.yaxis.axis_label = "y-centroid"
+
+
+        # - - - Periodogram - - - 
+        # - - - - - - - - - - - - - 
+
+        self.source_periodgrm = ColumnDataSource(
+            data=dict(x_periodgrm=[], y_periodgrm=[]))
+        
+        self.source_periodgrm_smooth = ColumnDataSource(
+            data=dict(x_periodgrm_smooth=[], y_periodgrm_smooth=[]))
+
+        # add an extra figure to plot an additional parameter - such as the background or the centroid shifts. 
+        self.plot_periodgrm = figure(
+            plot_height=300, plot_width=500, title="", sizing_mode="scale_both", x_axis_type="log", y_axis_type="log")
+
+        self.plot_periodgrm.line(
+            x="x_periodgrm",
+            y="y_periodgrm",
+            source=self.source_periodgrm,
+            line_color="black",
+            color="black",
+            alpha=1,)
+
+        self.plot_periodgrm.line(
+            x="x_periodgrm_smooth",
+            y="y_periodgrm_smooth",
+            source=self.source_periodgrm_smooth,
+            line_color="red",
+            color="red",
+            alpha=1,)
+
+        self.plot_periodgrm.xaxis.axis_label = "Frequency (micro Hz)"
+        self.plot_periodgrm.yaxis.axis_label = "Power Spectral Density (A^2 mu Hz^-1"
+
+        # -    -    -    -    -
+
         # Register the callback
         self.parent.primary.source.selected.on_change("indices", self.callback)
+
 
     def callback(self, attr, old, new):
         """
@@ -469,25 +584,93 @@ class DeliLATTE(BaseTool):
                 srad,
             ) = download_data(ticid, binfac=5, test="no")
 
+
             print("... download done.")
 
             self.source.data = dict(x=alltime, y=allflux)
 
-            #
             self.source_binned.data = dict(
-                x_binned=alltimebinned, y_binned=allfluxbinned
-            )
+                x_binned=alltimebinned, y_binned=allfluxbinned)
 
-            # print(alltimebinned, allfluxbinned)
+            # - - - Backgrounds - - - -
+            # - - - - - - - - - - - - -
+            self.source_bkg.data = dict(
+                x_bkg=alltime, y_bkg=allfbkg)
+
+
+            # - - - Centroic Plot - - - 
+            # - - - - - - - - - - - - - 
+
+            self.source_xcen1.data = dict(
+                x_xcen1=alltimel2, y_xcen1=allx1)
+            self.source_xcen2.data = dict(
+                x_xcen2=alltimel2, y_xcen2=allx2)
+            
+            # -   -   -   -   -   -   -  
+            self.source_ycen1.data = dict(
+                x_ycen1=alltimel2, y_ycen1=ally1)
+            self.source_ycen2.data = dict(
+                x_ycen2=alltimel2, y_ycen2=ally2)
+
+            # - - - Periodogram - - - -
+            # - - - - - - - - - - - - -
+            finite_mask = np.isfinite(alltime) & np.isfinite(allflux) 
+
+            lc = lk.lightcurve.LightCurve(time = alltime[finite_mask], flux = allflux[finite_mask])
+    
+            lc = lc.remove_outliers().remove_nans()
+            ls = lc.to_periodogram(normalization = 'psd')
+    
+            smooth = ls.smooth(method='boxkernel', filter_width=20.)
+    
+            freq = ls.frequency
+            power = ls.power
+    
+            freq_smooth = smooth.frequency
+            power_smooth = smooth.power
+
+            self.source_periodgrm.data = dict(
+                x_periodgrm=freq, y_periodgrm=power)
+
+            self.source_periodgrm_smooth.data = dict(
+                x_periodgrm_smooth=freq_smooth, y_periodgrm_smooth=power_smooth)
+            
 
         else:
             # Clear the plot
             self.source.data = dict(x=[], y=[])
             self.source_binned.data = dict(x_binned=[], y_binned=[])
+            # - - - 
+            self.source_bkg.data = dict(x_bkg=[], y_bkg=[])
+            # - - -
+            self.source_xcen.data = dict(x_xcen1=[], y_xcen1=[])
+            self.source_xcen.data = dict(x_xcen2=[], y_xcen2=[])
+            self.source_ycen.data = dict(x_ycen1=[], y_ycen1=[])
+            self.source_ycen.data = dict(x_ycen2=[], y_ycen2=[])
+
+            self.source_periodgrm.data = dict(x_periodgrm=[], y_periodgrm=[])
+            self.source_periodgrm_smooth.data = dict(x_periodgrm_smooth=[], y_periodgrm_smooth=[])
 
             # self.plot.xaxis.axis_label = 'Time (BJD - 2457000)'
             # self.plot.yaxis.axis_label = 'Normalised Flux'
 
     def layout(self):
-        return self.plot
+
+
+        panels = [None, None, None]
+
+        # Main panel: data
+        panels[0] = Panel(child = self.plot_bkg, title = 'Background Flux')
+
+        # Secondary panel: appearance
+        panels[1] = Panel(child = column(self.plot_xcen, self.plot_ycen), title = 'Centroid Position')
+        
+        panels[2] = Panel(child = self.plot_periodgrm, title = 'Periodorgram')
+
+        # panels[1] = Panel(child=self.checkbox_group, title="appearance",)
+
+        tabs = Tabs(tabs=panels, css_classes=["tabs"])
+
+
+        return row(self.plot, tabs)
 


### PR DESCRIPTION
Update to the LATTE tool:
- displays LC of target below the main plotting region
- 3 tabs with background flux, x and y centroid positions, and a periodogram 

Still needs formatting to make it look nicer. 

Pending: 
- stop the reloading of data when a target is clicked on twice
- have something on the plot thats hows that the data is being downloaded
- additional plots could be added with the target pixel files, however, these files are large.
- could add tabs to look at data from individual sectors. 

No changes to main documents. 